### PR TITLE
ADDED the current version of protoBuf

### DIFF
--- a/tensorflow/tools/tf_sig_build_dockerfiles/devel.requirements.txt
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/devel.requirements.txt
@@ -15,7 +15,7 @@ numpy ~= 1.22.0; python_version < '3.11'
 numpy ~= 1.23.2; python_version >= '3.11' # Earliest version for Python 3.11
 opt_einsum ~= 3.3.0
 packaging ~= 21.3
-protobuf ~= 3.20.1
+protobuf ~= https://github.com/tensorflow/tensorflow/blob/20e0beaeebc1bd96c8eca40bed0e7b0d065d8e0b/tensorflow/tools/pip_package/setup.py#L100
 six ~= 1.16.0
 termcolor ~= 2.1.1
 typing_extensions ~= 3.10.0.0


### PR DESCRIPTION
Previously protobuf 3.20.1 was used, which was giving error for some of the units.